### PR TITLE
Merge new data with existing QSOs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,8 @@ require (
 	firebase.google.com/go/v4 v4.1.0
 	github.com/Matir/adifparser v0.0.0-20201018173435-4ff0e273b485
 	github.com/golang/protobuf v1.4.3
+	github.com/imdario/mergo v0.3.11
+	github.com/jinzhu/copier v0.0.0-20201025035756-632e723a6687
 	github.com/k0swe/adif-json-protobuf/go v0.0.0-20201018005139-9070f174b917
 	github.com/k0swe/qrz-logbook v0.0.5
 	golang.org/x/net v0.0.0-20201016165138-7b1cca2348c0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -127,6 +127,10 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/imdario/mergo v0.3.11 h1:3tnifQM4i+fbajXKBHXWEH+KvNHqojZ778UH75j3bGA=
+github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
+github.com/jinzhu/copier v0.0.0-20201025035756-632e723a6687 h1:bWXum+xWafUxxJpcXnystwg5m3iVpPYtrGJFc1rjfLc=
+github.com/jinzhu/copier v0.0.0-20201025035756-632e723a6687/go.mod h1:24xnZezI2Yqac9J61UC6/dG/k76ttpq0DdJI3QmUvro=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1 h1:6QPYqodiu3GuPL+7mfx+NwDdp2eTkp9IfEUpgAwUN0o=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
@@ -443,6 +447,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/import_qrz_test.go
+++ b/import_qrz_test.go
@@ -12,8 +12,8 @@ func Test_mergeQso(t *testing.T) {
 		backfill *adifpb.Qso
 	}
 	type returnValues struct {
-		diff      bool
-		returnQso *adifpb.Qso
+		diff    bool
+		wantQso *adifpb.Qso
 	}
 	tests := []struct {
 		name string
@@ -27,8 +27,8 @@ func Test_mergeQso(t *testing.T) {
 				backfill: &adifpb.Qso{Band: "20m", Mode: "CW"},
 			},
 			want: returnValues{
-				diff:      true,
-				returnQso: &adifpb.Qso{Band: "20m", Freq: 14.050, Mode: "CW"},
+				diff:    true,
+				wantQso: &adifpb.Qso{Band: "20m", Freq: 14.050, Mode: "CW"},
 			},
 		},
 		{
@@ -39,8 +39,8 @@ func Test_mergeQso(t *testing.T) {
 				backfill: &adifpb.Qso{Band: "20m", Freq: 14.051},
 			},
 			want: returnValues{
-				diff:      false,
-				returnQso: &adifpb.Qso{Band: "20m", Freq: 14.050, Mode: "CW"},
+				diff:    false,
+				wantQso: &adifpb.Qso{Band: "20m", Freq: 14.050, Mode: "CW"},
 			},
 		},
 		{
@@ -72,7 +72,57 @@ func Test_mergeQso(t *testing.T) {
 			},
 			want: returnValues{
 				diff: true,
-				returnQso: &adifpb.Qso{
+				wantQso: &adifpb.Qso{
+					Band: "40m",
+					Freq: 7.07595,
+					Mode: "FT8",
+					ContactedStation: &adifpb.Station{
+						StationCall: "K9IJ",
+						GridSquare:  "EN52",
+						OpName:      "JOHN F RICE",
+						City:        "LAKE ZURICH",
+						State:       "IL",
+						Country:     "United States",
+						Dxcc:        291,
+					},
+				},
+			},
+		},
+		{
+			name: "QrzcomPlusQrzcom",
+			args: args{
+				base: &adifpb.Qso{
+					Band: "40m",
+					Freq: 7.07595,
+					Mode: "FT8",
+					ContactedStation: &adifpb.Station{
+						StationCall: "K9IJ",
+						GridSquare:  "EN52",
+						OpName:      "JOHN F RICE",
+						City:        "LAKE ZURICH",
+						State:       "IL",
+						Country:     "United States",
+						Dxcc:        291,
+					},
+				},
+				backfill: &adifpb.Qso{
+					Band: "40m",
+					Freq: 7.07595,
+					Mode: "FT8",
+					ContactedStation: &adifpb.Station{
+						StationCall: "K9IJ",
+						GridSquare:  "EN52",
+						OpName:      "JOHN F RICE",
+						City:        "LAKE ZURICH",
+						State:       "IL",
+						Country:     "United States",
+						Dxcc:        291,
+					},
+				},
+			},
+			want: returnValues{
+				diff: false,
+				wantQso: &adifpb.Qso{
 					Band: "40m",
 					Freq: 7.07595,
 					Mode: "FT8",
@@ -95,8 +145,8 @@ func Test_mergeQso(t *testing.T) {
 			if diff != tt.want.diff {
 				t.Errorf("mergeQso() diff got = %v, want %v", diff, tt.want.diff)
 			}
-			if !reflect.DeepEqual(tt.args.base, tt.want.returnQso) {
-				t.Errorf("mergeQso() returnQso got = %v, want %v", tt.args.base, tt.want.returnQso)
+			if !reflect.DeepEqual(tt.args.base, tt.want.wantQso) {
+				t.Errorf("mergeQso() qso got = %v, want %v", tt.args.base, tt.want.wantQso)
 			}
 		})
 	}


### PR DESCRIPTION
Any brand new fields from QRZ.com will be merged into the Firestore documents. If Firestore already contains a field, QRZ.com information for that field will be ignored even if it's different. Maybe later we can devise an interactive process to resolve conflicts.

Resolves #10.